### PR TITLE
chore: create local environment for validate project

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ logs/
 # Added by cargo
 
 /target
+.direnv

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A RISC-V emulator in Rust, probably written by a cat. 🐈
 
 - **RV32IMA Instruction Set Support**: Complete implementation of RISC-V base integer (RV32I), multiplication (RV32M), and atomic (RV32A) instruction sets
 - **40+ Instructions Implemented**: All major RISC-V instruction types including arithmetic, logical, memory, branch, jump, and atomic operations
-- **ELF Binary Loading**: Parses and loads ELF binaries into emulator memory  
+- **ELF Binary Loading**: Parses and loads ELF binaries into emulator memory
 - **Memory Management**: HashMap-based memory with bounds checking and little-endian support
 - **Register File**: 32 general-purpose registers (x0-x31) with x0 hardwired to zero
 - **Instruction Execution**: Fetch-decode-execute cycle with instruction limits for safety
@@ -25,6 +25,64 @@ cargo build --release
 ```bash
 # Run an ELF binary through the emulator
 ./target/release/nekov path/to/program.elf
+```
+
+### Example Usage
+
+```bash
+./target/debug/nekov ./riscv-tests-binaries/share/riscv-tests/isa/rv32ui-p-addi -vvv --riscv-tests
+Nekov RISC-V Emulator
+Loading ELF binary: ./riscv-tests-binaries/share/riscv-tests/isa/rv32ui-p-addi
+RISC-V tests mode enabled
+Verbose output level: 3
+Loaded segment at 0x80000000 (size: 1148 bytes)
+Loaded segment at 0x80001000 (size: 72 bytes)
+Entry point: 0x80000000
+Starting emulation...
+=== Starting CPU execution (verbose level 3) ===
+
+Cycle 1: PC=0x80000000
+  Instruction: 0x0500006f
+  Before: x1=0x00000000 x2=0x00000000 x3=0x00000000 x10=0x00000000
+  Fetched instruction: 0x0500006f
+  Opcode: 0x6f
+  JAL instruction
+  After:  x1=0x00000000 x2=0x00000000 x3=0x00000000 x10=0x00000000
+
+(snipped)
+
+Cycle 277: PC=0x80000440
+  Instruction: 0x00000073
+  Before: x1=0x00000021 x2=0x00000000 x3=0x00000001 x10=0x00000000
+  Fetched instruction: 0x00000073
+  Opcode: 0x73
+  System instruction
+ECALL termination at PC: 0x80000440
+=== CPU execution completed ===
+Total instructions executed: 277
+Emulation completed. Executed 277 instructions.
+
+=== Final CPU State ===
+Final PC: 0x80000440
+Registers:
+x0: 0x00000000  x8: 0x00000000  x16: 0x00000000  x24: 0x00000000
+x1: 0x00000021  x9: 0x00000000  x17: 0x0000005d  x25: 0x00000000
+x2: 0x00000000  x10: 0x00000000  x18: 0x00000000  x26: 0x00000000
+x3: 0x00000001  x11: 0x00000018  x19: 0x00000000  x27: 0x00000000
+x4: 0x00000002  x12: 0x00000000  x20: 0x00000000  x28: 0x00000000
+x5: 0x00000002  x13: 0x7fffffff  x21: 0x00000000  x29: 0x00000000
+x6: 0x00000016  x14: 0x00000016  x22: 0x00000000  x30: 0x00000000
+x7: 0x00000000  x15: 0x00000000  x23: 0x00000000  x31: 0x00000000
+=== RISC-V Test Result Analysis ===
+Register state at termination:
+  gp (x3)  = 0x00000001 (TESTNUM)
+  a0 (x10) = 0x00000000 (exit code)
+  a7 (x17) = 0x0000005d (syscall number)
+
+Test result determination:
+  ✓ System call number is 93 (exit syscall)
+  ✓ TESTNUM=1 and exit code=0 → PASS
+RISC-V test PASSED
 ```
 
 ## Testing
@@ -54,41 +112,45 @@ cargo run --bin instruction_test
 ### Supported Instructions
 
 #### RV32I Base Integer Instructions
-| Category | Instructions | Status |
-|----------|--------------|---------|
-| **I-type Arithmetic** | ADDI, SLTI, SLTIU, ANDI, ORI, XORI | ✅ |
-| **I-type Shifts** | SLLI, SRLI, SRAI | ✅ |
-| **R-type Arithmetic** | ADD, SUB, SLT, SLTU | ✅ |
-| **R-type Logical** | AND, OR, XOR | ✅ |
-| **R-type Shifts** | SLL, SRL, SRA | ✅ |
-| **Load** | LB, LH, LW, LBU, LHU | ✅ |
-| **Store** | SB, SH, SW | ✅ |
-| **Branch** | BEQ, BNE, BLT, BGE, BLTU, BGEU | ✅ |
-| **Jump** | JAL, JALR | ✅ |
-| **Upper Immediate** | LUI, AUIPC | ✅ |
-| **System** | ECALL, EBREAK | ✅ |
 
-#### RV32M Multiplication Extension  
-| Category | Instructions | Status |
-|----------|--------------|---------|
-| **Multiplication** | MUL, MULH, MULHSU, MULHU | ✅ |
-| **Division** | DIV, DIVU, REM, REMU | ✅ |
+| Category              | Instructions                       | Status |
+| --------------------- | ---------------------------------- | ------ |
+| **I-type Arithmetic** | ADDI, SLTI, SLTIU, ANDI, ORI, XORI | ✅     |
+| **I-type Shifts**     | SLLI, SRLI, SRAI                   | ✅     |
+| **R-type Arithmetic** | ADD, SUB, SLT, SLTU                | ✅     |
+| **R-type Logical**    | AND, OR, XOR                       | ✅     |
+| **R-type Shifts**     | SLL, SRL, SRA                      | ✅     |
+| **Load**              | LB, LH, LW, LBU, LHU               | ✅     |
+| **Store**             | SB, SH, SW                         | ✅     |
+| **Branch**            | BEQ, BNE, BLT, BGE, BLTU, BGEU     | ✅     |
+| **Jump**              | JAL, JALR                          | ✅     |
+| **Upper Immediate**   | LUI, AUIPC                         | ✅     |
+| **System**            | ECALL, EBREAK                      | ✅     |
+
+#### RV32M Multiplication Extension
+
+| Category           | Instructions             | Status |
+| ------------------ | ------------------------ | ------ |
+| **Multiplication** | MUL, MULH, MULHSU, MULHU | ✅     |
+| **Division**       | DIV, DIVU, REM, REMU     | ✅     |
 
 #### RV32A Atomic Extension
-| Category | Instructions | Status |
-|----------|--------------|---------|
-| **Load/Store Reserved** | LR.W, SC.W | ✅ |
-| **Atomic Memory Ops** | AMOSWAP.W, AMOADD.W, AMOXOR.W | ✅ |
-| **Atomic Logical** | AMOAND.W, AMOOR.W | ✅ |
-| **Atomic Min/Max** | AMOMIN.W, AMOMAX.W, AMOMINU.W, AMOMAXU.W | ✅ |
+
+| Category                | Instructions                             | Status |
+| ----------------------- | ---------------------------------------- | ------ |
+| **Load/Store Reserved** | LR.W, SC.W                               | ✅     |
+| **Atomic Memory Ops**   | AMOSWAP.W, AMOADD.W, AMOXOR.W            | ✅     |
+| **Atomic Logical**      | AMOAND.W, AMOOR.W                        | ✅     |
+| **Atomic Min/Max**      | AMOMIN.W, AMOMAX.W, AMOMINU.W, AMOMAXU.W | ✅     |
 
 **Total: 50+ instructions implemented covering RV32IMA**
 
 ### Test Results
 
 The emulator passes all 27 unit tests including:
+
 - **I-type instructions**: ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI
-- **R-type instructions**: ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND  
+- **R-type instructions**: ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND
 - **M-type instructions**: MUL, MULH, DIV, DIVU, REM, REMU with proper overflow handling
 - **Load/Store operations**: All memory access patterns with proper alignment
 - **Branch instructions**: Conditional branching with correct offset calculation
@@ -100,6 +162,7 @@ The emulator passes all 27 unit tests including:
 ## Development
 
 This project follows a TDD (Test-Driven Development) approach with:
+
 - Unit tests for all components
 - Integration tests using real instruction sequences
 - CI pipeline ensuring code quality
@@ -119,8 +182,9 @@ This project follows a TDD (Test-Driven Development) approach with:
 ```
 
 **Instruction Pipeline:**
+
 1. **Fetch**: Read 32-bit instruction from memory at PC
-2. **Decode**: Parse instruction format (R/I/S/B/U/J) and extract fields  
+2. **Decode**: Parse instruction format (R/I/S/B/U/J) and extract fields
 3. **Execute**: Perform operation based on instruction type:
    - **Arithmetic**: ALU operations with proper overflow handling
    - **Memory**: Load/store with alignment checks and endianness
@@ -134,16 +198,19 @@ This project follows a TDD (Test-Driven Development) approach with:
 Before submitting a PR, ensure the following requirements are met:
 
 1. **Linting**: Code must pass all linting checks
+
    ```bash
    cargo clippy -- -D warnings
    ```
 
 2. **Formatting**: Code must be properly formatted
+
    ```bash
    cargo fmt --check
    ```
 
-3. **Build**: Code must build successfully  
+3. **Build**: Code must build successfully
+
    ```bash
    cargo build
    ```
@@ -156,7 +223,7 @@ These are mandatory requirements that will be checked before any PR review.
 
 1. Fork the repository
 2. Create a feature branch
-3. Add tests for new functionality  
+3. Add tests for new functionality
 4. Ensure all tests pass: `cargo test && ./scripts/test.sh`
 5. Run lint, format, and build checks (see requirements above)
 6. Submit a pull request

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752330909,
+        "narHash": "sha256-Y3FLmh6uN2EB8QGNqSz1q50qQG0IalnbqIIkk3CqSKM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "84ede95bf803fba306baac52bccf05d49a114061",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+    description = "RISCV binary toolchain";
+
+    inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs";
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = { self, nixpkgs, flake-utils, }: 
+        flake-utils.lib.eachDefaultSystem (system:
+        let
+            pkgs = import nixpkgs { inherit system; };
+            crossPkgs = pkgs.pkgsCross.riscv64-embedded;
+        in
+        {
+            packages.default = crossPkgs.mkShell {
+                nativeBuildInputs = with pkgs; [
+                ];
+            };
+        });
+}

--- a/scripts/build_riscv_tests.sh
+++ b/scripts/build_riscv_tests.sh
@@ -32,9 +32,18 @@ print_status() {
     esac
 }
 
+# Initialize and update all submodules
+print_status "INFO" "Initializing and updating submodules..."
+cd "$PROJECT_DIR"
+if ! git submodule update --init --recursive; then
+    print_status "FAIL" "Failed to initialize submodules"
+    exit 1
+fi
+print_status "PASS" "Submodules initialized successfully"
+
 # Check if RISC-V toolchain is available
-if ! command -v riscv64-unknown-elf-gcc &> /dev/null && ! command -v riscv32-unknown-elf-gcc &> /dev/null; then
-    print_status "FAIL" "RISC-V toolchain not found. Please install gcc-riscv64-unknown-elf"
+if ! command -v riscv64-unknown-elf-gcc &> /dev/null && ! command -v riscv64-none-elf-gcc &> /dev/null && ! command -v riscv32-unknown-elf-gcc &> /dev/null; then
+    print_status "FAIL" "RISC-V toolchain not found. Please install gcc-riscv64-unknown-elf or gcc-riscv64-none-elf"
     exit 1
 fi
 
@@ -42,6 +51,9 @@ fi
 if command -v riscv64-unknown-elf-gcc &> /dev/null; then
     RISCV_PREFIX="riscv64-unknown-elf-"
     print_status "INFO" "Using riscv64-unknown-elf toolchain"
+elif command -v riscv64-none-elf-gcc &> /dev/null; then
+    RISCV_PREFIX="riscv64-none-elf-"
+    print_status "INFO" "Using riscv64-none-elf toolchain"
 elif command -v riscv32-unknown-elf-gcc &> /dev/null; then
     RISCV_PREFIX="riscv32-unknown-elf-"
     print_status "INFO" "Using riscv32-unknown-elf toolchain"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 RISCV_TESTS_BINARIES_DIR="$PROJECT_DIR/riscv-tests-binaries"
 # Determine verbose flag
-VERBOSE_FLAG=${VERBOSE_FLAG:-""}
+VERBOSE_FLAG="$1"
 
 # Colors for output
 RED='\033[0;31m'

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 RISCV_TESTS_BINARIES_DIR="$PROJECT_DIR/riscv-tests-binaries"
+# Determine verbose flag
+VERBOSE_FLAG=${VERBOSE_FLAG:-""}
 
 # Colors for output
 RED='\033[0;31m'
@@ -84,13 +86,6 @@ echo
 cd "$PROJECT_DIR"
 # Create logs directory for CI artifacts
 mkdir -p logs
-
-# Determine verbose flag - use -v if CI environment detected
-VERBOSE_FLAG=""
-if [ "${CI:-false}" = "true" ] || [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
-    VERBOSE_FLAG="-v"
-    print_status "INFO" "CI environment detected, running with verbose output (-v)"
-fi
 
 # Run tests and capture output for CI artifacts
 cargo run --bin test_runner "$PROJECT_DIR/target/release/nekov" "$TESTS_ISA_DIR" $VERBOSE_FLAG > logs/riscv-tests-results.log


### PR DESCRIPTION
This pull request introduces several updates to improve the RISC-V emulator project, including enhancements to the build process, documentation, and testing scripts. Key changes include the addition of a Nix flake for dependency management, expanded README documentation, and updates to scripts for better submodule handling and toolchain detection.

### Build and Dependency Management:
* Added a `flake.nix` file to manage dependencies using Nix, including a RISC-V binary toolchain setup. This simplifies the development environment setup.
* Updated `.envrc` to use the Nix flake for managing dependencies (`use flake`).

### Documentation Enhancements:
* Expanded the `README.md` with an example usage section showcasing the emulator in action, detailed outputs, and test result analysis.
* Improved formatting and organization of supported instructions, test results, and development practices in the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R115-R117) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R131-R140) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R185)

### Script Improvements:
* Updated `scripts/build_riscv_tests.sh` to initialize and update submodules automatically and added support for detecting the `riscv64-none-elf-gcc` toolchain.
* Simplified `scripts/test.sh` by removing redundant verbose flag detection for CI environments, making the script more streamlined. [[1]](diffhunk://#diff-52afcc694c0ff8ff253441f42ff44d6b4734fe30ae9070f2ba07a668a10e7baaR11-R12) [[2]](diffhunk://#diff-52afcc694c0ff8ff253441f42ff44d6b4734fe30ae9070f2ba07a668a10e7baaL88-L94)